### PR TITLE
fix(demo-app): Fix lint warning

### DIFF
--- a/packages/demo-app/src/App.tsx
+++ b/packages/demo-app/src/App.tsx
@@ -57,7 +57,7 @@ const App = () => {
     <div className="App">
       <div className="App__link-to-repo">
         <a href="https://github.com/chloe463/yorha/tree/master/packages/use-form-group">
-          <img src={octocat} />
+          <img src={octocat} alt="octocat" />
         </a>
       </div>
 


### PR DESCRIPTION
## Why

`yarn build` is failed on CD (netlify) because of lint warning.

![image](https://user-images.githubusercontent.com/6651523/89056352-db898780-d396-11ea-9de8-635b968183a4.png)

## What

Fixed `jsx-a11y/alt-text` warning